### PR TITLE
Fix the link of Pro Javascript Design Patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,6 @@ All constructive comments are welcome. I promise I will answer everyone.
 
 [Head First Design Patterns](http://www.amazon.com/First-Design-Patterns-Elisabeth-Freeman/dp/0596007124/ref=sr_1_1?ie=UTF8&qid=1316512770&sr=8-1)
 
-[Pro Javascript Design Patterns](http://www.amazon.com/Pro-JavaScript-Design-Patterns-ebook/dp/B001AT1YUA/ref=sr_1_2?ie=UTF8&qid=1317818607&sr=8-2)
+[Pro Javascript Design Patterns](http://www.amazon.com/Pro-JavaScript-Design-Patterns-Object-Oriented/dp/159059908X)  
+
 __


### PR DESCRIPTION
The original amazon's link of Pro Javascript Design Patterns is no longer available.
